### PR TITLE
Fix crash after 2nd launch

### DIFF
--- a/src/main/java/dev/lvstrng/argon/gui/ClickGui.java
+++ b/src/main/java/dev/lvstrng/argon/gui/ClickGui.java
@@ -40,6 +40,14 @@ public final class ClickGui extends Screen {
 	}
 
 	@Override
+	protected void setInitialFocus() {
+		if (client == null) {
+			return;
+		}
+		super.setInitialFocus();
+	}
+
+	@Override
 	public void render(DrawContext context, int mouseX, int mouseY, float delta) {
 		if (mc.currentScreen == this) {
 			if (Argon.INSTANCE.previousScreen != null)


### PR DESCRIPTION
While this does fix the current issue, I'm pretty sure setting the screen to the Argon ClickGui from net.fabricmc.api.ModInitializer.onInitialize() can have other unintended side effects.