### PR TITLE
Wtap fixes

### DIFF
--- a/src/main/java/dev/lvstrng/argon/module/modules/combat/AutoWTap.java
+++ b/src/main/java/dev/lvstrng/argon/module/modules/combat/AutoWTap.java
@@ -64,7 +64,7 @@ public final class AutoWTap extends Module implements PacketSendListener, HudLis
 			jumpedWhileHitting = false;
 		}
 
-		if (GLFW.glfwGetKey(mc.getWindow().getHandle(), GLFW.GLFW_KEY_SPACE) == 1) {
+		if (GLFW.glfwGetKey(mc.getWindow().getHandle(), GLFW.GLFW_KEY_SPACE) == 1 && !inAir.getValue()) {
 			if (holdingForward || sprinting) {
 				mc.options.forwardKey.setPressed(true);
 				holdingForward = false;
@@ -103,7 +103,7 @@ public final class AutoWTap extends Module implements PacketSendListener, HudLis
 
 			@Override
 			public void attack() {
-				if (GLFW.glfwGetKey(mc.getWindow().getHandle(), GLFW.GLFW_KEY_SPACE) == 1) {
+				if (GLFW.glfwGetKey(mc.getWindow().getHandle(), GLFW.GLFW_KEY_SPACE) == 1 && !inAir.getValue()) {
 					jumpedWhileHitting = true;
 				}
 


### PR DESCRIPTION
Fixes a few issues with the w-tap
- Fixed it inAir w-taps from happening even when disabled
- Made it so that that if a user hits and jumps another player it does not continue the w-tap after landing (new bug after I fixed previous thing). Resulting in a better experience when combo'ing people.

Here is a video link of it working.
https://cyde.arabs-for.sale/6CI98.mp4